### PR TITLE
Create .gitattributes file.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,9 @@ module.exports = {
   ],
   'rules': {
     'react/react-in-jsx-scope': 'off',
+    'linebreak-style': [
+      'error',
+      process.platform === 'win32' ? 'windows' : 'unix',
+    ],
   },
 };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Bug describe: 
When we "npm start". we will found this. This is because Eslint check linebreaks.
![image](https://github.com/keelworks/Portfolio-Generator-frontend/assets/56906163/0f3b5bc9-a01a-4ba2-900b-ba473ad2319a)

How to test:
switch to current branch and "npm start". The bug not exist anymore.